### PR TITLE
Use maintained GitHub Action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-python@v1
 
       - name: Install Poetry
-        uses: dschep/install-poetry-action@v1.2
+        uses: snok/install-poetry@v1.1.4
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v1
@@ -52,7 +52,7 @@ jobs:
           architecture: x64
 
       - name: Install Poetry
-        uses: dschep/install-poetry-action@v1.2
+        uses: snok/install-poetry@v1.1.4
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v1


### PR DESCRIPTION
The current GitHub action `dschep/install-poetry-action@v1.2` lets all checks fail.

On the action's repo (https://github.com/dschep/install-poetry-action) it says: "THIS ACTION IS NOT MAINTAINED. USE https://github.com/snok/install-poetry INSTEAD!"

This PR switches the GitHub action that installs poetry to the recommended one.