### PR TITLE
Add new write result function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,7 @@ _________
 * **print_result** - Formats nicely and prints results on stdout.
 * **print_title** - Formats nicely a title and prints it on stdout.
 * **print_stat** - Prints result statistic on stdout. 
+* **write_result** - Write result to file.
 
 Processors
 __________

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ _________
 
 * **print_result** - Formats nicely and prints results on stdout.
 * **print_title** - Formats nicely a title and prints it on stdout.
+* **print_stat** - Prints result statistic on stdout. 
 
 Processors
 __________

--- a/nornir_utils/plugins/functions/__init__.py
+++ b/nornir_utils/plugins/functions/__init__.py
@@ -1,3 +1,12 @@
-from .print_result import print_result, print_title
+from .print_result import (
+    print_result,
+    print_title,
+)
 
-__all__ = ("print_result", "print_title")
+from .print_stat import print_stat
+
+__all__ = (
+    "print_result",
+    "print_title",
+    "print_stat",
+)

--- a/nornir_utils/plugins/functions/__init__.py
+++ b/nornir_utils/plugins/functions/__init__.py
@@ -4,9 +4,11 @@ from .print_result import (
 )
 
 from .print_stat import print_stat
+from .write_result import write_result
 
 __all__ = (
     "print_result",
     "print_title",
     "print_stat",
+    "write_result",
 )

--- a/nornir_utils/plugins/functions/print_stat.py
+++ b/nornir_utils/plugins/functions/print_stat.py
@@ -1,0 +1,126 @@
+import threading
+from itertools import islice
+from typing import Optional, Tuple
+from colorama import Fore, Style, init
+from nornir_utils.plugins.functions.print_result import _get_color
+from nornir.core.task import AggregatedResult, MultiResult, Result
+
+
+LOCK = threading.Lock()
+
+init(autoreset=True, strip=False)
+
+
+def _print_individual_stat(
+    result: Result,
+    res_sum: int = 0,
+    ch_sum: int = 0,
+    f_sum: int = 0,
+) -> Tuple[int, int, int]:
+
+    f, ch = (result.failed, result.changed)
+
+    res_sum += 1
+    ch_sum += int(ch)
+    f_sum += int(f)
+
+    color = _get_color(result, f)
+    msg = "{:<35} ok={:<15} changed={:<15} failed={:<15}".format(
+        result.name, not f, ch, f
+    )
+    print("    {}{}{}".format(Style.BRIGHT, color, msg))
+    return res_sum, ch_sum, f_sum
+
+
+def _print_stat(
+    result: Result,
+    count: Optional[int] = None,
+    res_sum: int = 0,
+    ch_sum: int = 0,
+    f_sum: int = 0,
+) -> Tuple[int, int, int]:
+
+    if isinstance(result, AggregatedResult):
+        msg = result.name
+        msg = "{}{}{}{}".format(Style.BRIGHT, Fore.CYAN, msg, "*" * (
+            80 - len(msg))
+        )
+
+        result = dict(sorted(result.items()))
+
+        if count != 0:
+            print(msg)
+        if isinstance(count, int):
+            length = len(result)
+            if count >= 0:
+                _ = [0, length and count]
+            elif (length + count) < 0:
+                _ = [0, length]
+            else:
+                _ = [length + count, length]
+            result = dict(islice(result.items(), *_))
+
+        for host, host_data in result.items():
+            msg_host = "* {} ".format(host)
+            print(
+                "{}{}{}{}".format(Style.BRIGHT, Fore.BLUE, msg_host, "*" * (
+                    80 - len(msg_host))
+                )
+            )
+            res_sum, ch_sum, f_sum = _print_stat(
+                host_data,
+                count,
+                res_sum,
+                ch_sum,
+                f_sum
+            )
+    elif isinstance(result, MultiResult):
+        for res in result:
+            res_sum, ch_sum, f_sum = _print_stat(
+                res,
+                count,
+                res_sum,
+                ch_sum,
+                f_sum
+            )
+    elif isinstance(result, Result):
+        res_sum, ch_sum, f_sum = _print_individual_stat(
+            result,
+            res_sum,
+            ch_sum,
+            f_sum
+        )
+
+    return res_sum, ch_sum, f_sum
+
+
+def print_stat(result: Result, count: Optional[int] = None) -> None:
+    """
+    Prints statistic for `nornir.core.task.Result` object
+
+    Arguments:
+
+      result: from a previous task
+
+      count: Number of sorted results. It's acceptable
+      to use numbers with minus sign(-5 as example),
+      then results will be from the end of results list
+    """
+    LOCK.acquire()
+    try:
+        res_sum, ch_sum, f_sum = _print_stat(
+            result,
+            count=count,
+            res_sum=0,
+            ch_sum=0,
+            f_sum=0,
+        )
+        print()
+        for state, summary, color in zip(
+            ("OK", "CHANGED", "FAILED"),
+            (res_sum - f_sum, ch_sum, f_sum),
+            (Fore.GREEN, Fore.YELLOW, Fore.RED),
+        ):
+            print("{}{}{:<8}: {}".format(Style.BRIGHT, color, state, summary))
+    finally:
+        LOCK.release()

--- a/nornir_utils/plugins/functions/write_result.py
+++ b/nornir_utils/plugins/functions/write_result.py
@@ -1,0 +1,229 @@
+import os
+import difflib
+import logging
+import threading
+import json
+from pathlib import Path
+from itertools import islice
+from typing import List, Optional, IO, AnyStr
+from nornir.core.task import AggregatedResult, MultiResult, Result
+from nornir_utils.plugins.tasks.files.write_file import _read_file
+
+
+LOCK = threading.Lock()
+
+
+def _generate_diff(
+    old_lines: List[str],
+    new_lines: str,
+    append: bool,
+    filename: str,
+) -> str:
+    if append:
+        c = list(old_lines)
+        c.extend(new_lines.splitlines())
+        new_content = c
+    else:
+        new_content = new_lines.splitlines()
+
+    diff = difflib.unified_diff(
+        old_lines, new_content, fromfile=filename, tofile="new"
+    )
+
+    return "\n".join(diff)
+
+
+def _write_individual_result(
+    result: Result,
+    io: IO[AnyStr],
+    attrs: List[str],
+    failed: bool,
+    severity_level: int,
+    task_group: bool = False,
+    write_host: bool = False,
+    no_errors: bool = False,
+    content: List[str] = [],
+) -> List[str]:
+
+    # ignore results with a specifig severity_level
+    if result.severity_level < severity_level:
+        return content
+
+    # ignore results with errors
+    if no_errors:
+        if result.exception:
+            return content
+
+    subtitle = (
+        "" if result.changed is None else " ** changed : {} ".format(
+            result.changed
+        )
+    )
+    level_name = logging.getLevelName(result.severity_level)
+    symbol = "v" if task_group else "-"
+    host = (
+        f"{result.host.name}: "
+        if (write_host and result.host and result.host.name)
+        else ""
+    )
+    msg = "{} {}{}{}".format(symbol * 4, host, result.name, subtitle)
+    content.append("{}{} {}".format(msg, symbol * (80 - len(msg)), level_name))
+    for attribute in attrs:
+        x = getattr(result, attribute, "")
+        if isinstance(x, BaseException):
+            # for consistency between py3.6 and py3.7
+            content.append(f"{x.__class__.__name__}{x.args}")
+        elif x and not isinstance(x, str):
+            try:
+                content.append(
+                    json.dumps(
+                        x, indent=2, ensure_ascii=False
+                    ).encode("utf-8").decode()
+                )
+            except TypeError:
+                content.append(str(x))
+        elif x:
+            content.append(x)
+
+    return content
+
+
+def _write_result(
+    result: Result,
+    io: IO[AnyStr],
+    attrs: List[str] = None,
+    failed: bool = False,
+    severity_level: int = logging.INFO,
+    write_host: bool = False,
+    count: Optional[int] = None,
+    no_errors: bool = False,
+    content: List[str] = [],
+) -> List[str]:
+
+    attrs = attrs or ["diff", "result", "stdout"]
+    if isinstance(attrs, str):
+        attrs = [attrs]
+
+    if isinstance(result, AggregatedResult):
+        result = dict(sorted(result.items()))
+
+        if isinstance(count, int):
+            length = len(result)
+            if count >= 0:
+                _ = [0, length and count]
+            elif (length + count) < 0:
+                _ = [0, length]
+            else:
+                _ = [length + count, length]
+            result = dict(islice(result.items(), *_))
+
+        for host_data in result.values():
+            content = _write_result(
+                host_data,
+                io,
+                attrs,
+                failed,
+                severity_level,
+                write_host,
+                no_errors=no_errors,
+                content=content,
+            )
+    elif isinstance(result, MultiResult):
+        for r in result:
+            content = _write_result(
+                r,
+                io,
+                attrs,
+                failed,
+                severity_level,
+                write_host,
+                no_errors=no_errors,
+                content=content,
+            )
+    elif isinstance(result, Result):
+        content = _write_individual_result(
+            result,
+            io,
+            attrs,
+            failed,
+            severity_level,
+            write_host=write_host,
+            no_errors=no_errors,
+            content=content,
+        )
+
+    return content
+
+
+def write_result(
+    result: Result,
+    filename: str,
+    vars: List[str] = None,
+    failed: bool = False,
+    severity_level: int = logging.INFO,
+    write_host: bool = True,
+    count: Optional[int] = None,
+    append: bool = False,
+    no_errors: bool = False,
+) -> str:
+    """
+    Writes an object of type `nornir.core.task.Result` to file
+
+    Arguments:
+      result: from a previous task (Result or AggregatedResult or MultiResult)
+
+      filename: file you want to write the result
+
+      vars: Which attributes you want to write(see ``class Result`` attributes)
+
+      failed: if ``True`` assume the task failed
+
+      severity_level: Print only errors with this severity level or higher
+
+      write_host: Write hostname to file
+
+      count: Number of sorted results. It's acceptable
+      to use numbers with minus sign(-5 as example),
+      then results will be from the end of results list
+
+      append: "a+" if ``True`` or "w+" if ``False``
+
+      no_errors: Don't write results with errors
+    """
+    old_lines = _read_file(filename)
+
+    dirname = os.path.dirname(filename)
+    Path(dirname).mkdir(parents=True, exist_ok=True)
+
+    mode = "a+" if append else "w+"
+
+    LOCK.acquire()
+
+    try:
+        with open(filename, mode=mode) as f:
+            content: List[str] = _write_result(
+                result,
+                io=f,
+                attrs=vars,
+                failed=failed,
+                severity_level=severity_level,
+                write_host=write_host,
+                count=count,
+                no_errors=no_errors,
+                content=[],
+            )
+
+            lf = '\n\n' if Path(
+                filename
+            ).stat().st_size != 0 and append else ''
+
+            lines = [line.strip() for line in content]
+            line = lf + "\n\n".join(lines)
+
+            f.write(line)
+
+        diff = _generate_diff(old_lines, line, append, filename)
+
+        return diff
+    finally:
+        LOCK.release()


### PR DESCRIPTION
`write_result`:
- function writes `Result` object to file
- `write_result` returns diff between old file and new file (`str`)
- parameters:
  - `filename` - file you want to write the result. `write_result` creates dirs with `filename` if it's necessary
  - `vars`, `failed`, `severety_level`
  - `write_host` - write hostname to file or not
  - `count` is the same that `count` from `print_result`. It's number of sorted results (-5 or 5, for example). It can be useful for a large number of identical results. It's acceptable to use numbers with minus sign(-5 as example), then results will be from the end of results list.
  - `append` - "a+" or "w+" mode
  - `no_errors` - dont't write result with errors to file