### PR TITLE
added condition for task footer in print_result

### DIFF
--- a/nornir_utils/plugins/functions/print_result.py
+++ b/nornir_utils/plugins/functions/print_result.py
@@ -114,7 +114,8 @@ def _print_result(
             _print_result(r, attrs, failed, severity_level)
         color = _get_color(result[0], failed)
         msg = "^^^^ END {} ".format(result[0].name)
-        print("{}{}{}{}".format(Style.BRIGHT, color, msg, "^" * (80 - len(msg))))
+        if result[0].severity_level >= severity_level:
+            print("{}{}{}{}".format(Style.BRIGHT, color, msg, "^" * (80 - len(msg))))
     elif isinstance(result, Result):
         _print_individual_result(
             result, attrs, failed, severity_level, print_host=print_host


### PR DESCRIPTION
This fixes a problem with _print_result_ whereas when when running a task within a task and filtering out the output the footer for the subtask is still printed. For example with the below code without the fix it will still print the footer for task1, task2 and task3.

```
def dont_print_task(task: Task):
    task.run(task=echo_data, text="This Task should not be printed")

def main_task(task: Task):
    task.run(name="task1", task=dont_print_task, severity_level=logging.DEBUG)
    task.run(name="task2", task=dont_print_task, severity_level=logging.DEBUG)
    task.run(name="task3", task=dont_print_task, severity_level=logging.DEBUG)

result = nr.run(task=main_task)
```

I added an if statement to the printing of the footer to make it conditional based on severity. Not sure if you need me to do anything else, like testing, etc. Stuff on documentation was on about core, am assuming this is not so wasn't sure. Let me know if I need to do anything else or point me in the right direct.