### PR TITLE
[Feat]: use ipv6 socket in tcp_ping task

### DIFF
--- a/nornir_utils/plugins/tasks/networking/tcp_ping.py
+++ b/nornir_utils/plugins/tasks/networking/tcp_ping.py
@@ -5,7 +5,7 @@ from nornir.core.task import Result, Task
 
 
 def tcp_ping(
-    task: Task, ports: List[int], timeout: int = 2, host: Optional[str] = None
+    task: Task, ports: List[int], timeout: int = 2, host: Optional[str] = None, ipv6: bool = False
 ) -> Result:
     """
     Tests connection to a tcp port and tries to establish a three way
@@ -36,7 +36,10 @@ def tcp_ping(
 
     result = {}
     for port in ports:
-        s = socket.socket()
+        if ipv6:
+            s = socket.socket(socket.AF_INET6)
+        else:
+            s = socket.socket()
         s.settimeout(timeout)
         try:
             status = s.connect_ex((host, port))

--- a/nornir_utils/plugins/tasks/networking/tcp_ping.py
+++ b/nornir_utils/plugins/tasks/networking/tcp_ping.py
@@ -15,6 +15,7 @@ def tcp_ping(
         ports (list of int): tcp ports to ping
         timeout (int, optional): defaults to 2
         host (string, optional): defaults to ``hostname``
+        ipv6 (bool): use ipv6 socket. defaults to ``False``
 
 
     Returns:


### PR DESCRIPTION
Simple PR to enable ipv6 tcp tests.

Please let me know if I missed anything.
Any input is appreciated.

Best,
Dave