### PR TITLE
Modernize type annotations to PEP 585/604 syntax

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 import sys
-from typing import List
 
 sys.path.insert(0, "../")
 
@@ -41,7 +40,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: List[str] = []
+exclude_patterns: list[str] = []
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/nornir_utils/plugins/functions/print_result.py
+++ b/nornir_utils/plugins/functions/print_result.py
@@ -1,7 +1,7 @@
 import logging
 import pprint
 import threading
-from typing import List, cast, Optional, Union
+from typing import cast
 from collections import OrderedDict
 import json
 
@@ -36,7 +36,7 @@ def _get_color(result: Result, failed: bool) -> str:
 
 def _print_individual_result(
     result: Result,
-    attrs: List[str],
+    attrs: list[str],
     failed: bool,
     severity_level: int,
     task_group: bool = False,
@@ -67,8 +67,8 @@ def _print_individual_result(
 
 
 def _print_result(
-    result: Union[Result, AggregatedResult, MultiResult],
-    attrs: Optional[List[str]] = None,
+    result: Result | AggregatedResult | MultiResult,
+    attrs: list[str] | None = None,
     failed: bool = False,
     severity_level: int = logging.INFO,
     print_host: bool = False,
@@ -107,8 +107,8 @@ def _print_result(
 
 
 def print_result(
-    result: Union[Result, AggregatedResult, MultiResult],
-    vars: Optional[List[str]] = None,
+    result: Result | AggregatedResult | MultiResult,
+    vars: list[str] | None = None,
     failed: bool = False,
     severity_level: int = logging.INFO,
 ) -> None:

--- a/nornir_utils/plugins/inventory/transform_functions.py
+++ b/nornir_utils/plugins/inventory/transform_functions.py
@@ -1,11 +1,8 @@
 import os
-from typing import Optional
 from nornir.core.inventory import Host
 
 
-def load_credentials(
-    host: Host, username: Optional[str] = None, password: Optional[str] = None
-) -> None:
+def load_credentials(host: Host, username: str | None = None, password: str | None = None) -> None:
     """
     load_credentials is an transform_functions to add credentials to every host.
     Environment variables `NORNIR_USERNAME` and `NORNIR_PASSWORD` or arguments can be used.

--- a/nornir_utils/plugins/inventory/yaml_inventory.py
+++ b/nornir_utils/plugins/inventory/yaml_inventory.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from typing import Any, Dict, Type
+from typing import Any
 
 from nornir.core.inventory import (
     Inventory,
@@ -19,7 +19,7 @@ import ruamel.yaml
 logger = logging.getLogger(__name__)
 
 
-def _get_connection_options(data: Dict[str, Any]) -> Dict[str, ConnectionOptions]:
+def _get_connection_options(data: dict[str, Any]) -> dict[str, ConnectionOptions]:
     cp = {}
     for cn, c in data.items():
         cp[cn] = ConnectionOptions(
@@ -33,7 +33,7 @@ def _get_connection_options(data: Dict[str, Any]) -> Dict[str, ConnectionOptions
     return cp
 
 
-def _get_defaults(data: Dict[str, Any]) -> Defaults:
+def _get_defaults(data: dict[str, Any]) -> Defaults:
     return Defaults(
         hostname=data.get("hostname"),
         port=data.get("port"),
@@ -46,7 +46,7 @@ def _get_defaults(data: Dict[str, Any]) -> Defaults:
 
 
 def _get_inventory_element(
-    typ: Type[HostOrGroup], data: Dict[str, Any], name: str, defaults: Defaults
+    typ: type[HostOrGroup], data: dict[str, Any], name: str, defaults: Defaults
 ) -> HostOrGroup:
     return typ(
         name=name,

--- a/nornir_utils/plugins/processors/print_result.py
+++ b/nornir_utils/plugins/processors/print_result.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from typing import Union, cast
+from typing import cast
 
 from colorama import Fore, Style, init
 
@@ -10,7 +10,7 @@ from nornir.core.task import AggregatedResult, MultiResult, Result, Task
 init(autoreset=True, strip=False)
 
 
-def _get_color(result: Union[MultiResult, Result]) -> str:
+def _get_color(result: MultiResult | Result) -> str:
     if result.failed:
         color = Fore.RED
     elif result.changed:

--- a/nornir_utils/plugins/tasks/files/write_file.py
+++ b/nornir_utils/plugins/tasks/files/write_file.py
@@ -1,11 +1,10 @@
 import difflib
 import os
-from typing import List, Optional
 
 from nornir.core.task import Result, Task
 
 
-def _read_file(file: str) -> List[str]:
+def _read_file(file: str) -> list[str]:
     if not os.path.exists(file):
         return []
 
@@ -32,7 +31,7 @@ def write_file(
     filename: str,
     content: str,
     append: bool = False,
-    dry_run: Optional[bool] = None,
+    dry_run: bool | None = None,
 ) -> Result:
     """
     Write contents to a file (locally)

--- a/nornir_utils/plugins/tasks/networking/tcp_ping.py
+++ b/nornir_utils/plugins/tasks/networking/tcp_ping.py
@@ -1,10 +1,9 @@
 import socket
-from typing import Optional, List
 
 from nornir.core.task import Result, Task
 
 
-def tcp_ping(task: Task, ports: List[int], timeout: int = 2, host: Optional[str] = None) -> Result:
+def tcp_ping(task: Task, ports: list[int], timeout: int = 2, host: str | None = None) -> Result:
     """
     Tests connection to a tcp port and tries to establish a three way
     handshake. To be used for network discovery or testing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,9 @@ skip-magic-trailing-comma = false
 line-ending = "auto"
 
 [tool.ruff.lint]
-# Port of the previous pylama linters: pep8 (E/W) + pyflakes (F) + mccabe (C90)
-select = ["E", "W", "F", "C90"]
+# Port of the previous pylama linters: pep8 (E/W) + pyflakes (F) + mccabe (C90),
+# plus the pyupgrade rules that keep annotations on PEP 585/604 syntax.
+select = ["E", "W", "F", "C90", "UP006", "UP007", "UP035", "UP045"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10


### PR DESCRIPTION
## Summary

The plugin signatures that make up this library's public API were still written
with the legacy `typing` generics (`List[str]`, `Dict[str, Any]`, `Optional[X]`,
`Union[A, B]`). Since the project requires Python >=3.10, the built-in generics
and `X | Y` union syntax work on every supported interpreter, so those forms were
carried purely for historical reasons. Contributors reading or extending the
plugins now see one consistent, current style instead of two.

## Key Changes

- All 14 annotations across the plugins and `docs/source/conf.py` now use PEP 585
  builtins and PEP 604 unions; the `typing` imports that only existed to spell
  those types are gone.
- Ruff enforces the style going forward (`UP006`, `UP007`, `UP035`, `UP045`
  added to `lint.select`), so new contributions can't silently reintroduce the
  legacy forms.
- Scoped to those four rules deliberately — the full `UP` ruleset also flags 15
  unrelated f-string, `open()` mode, and exception-alias rewrites that don't
  belong in a typing change.

## Related Context

Closes #70.

## Test Plan

- `make ruff`, `make format`, `make mypy`, `make pytest` all pass locally.
- mypy runs at the pinned `1.0.1` against `python_version = "3.10"` and is clean —
  #70 flagged the pin as suspect because `yaml_inventory.py` had the heaviest
  annotation usage; it type-checks before and after.
- Annotations were additionally resolved at runtime under Python 3.10 (the
  `requires-python` floor) via `typing.get_type_hints`, since they're evaluated
  eagerly with no `from __future__ import annotations`.
- CI matrix covers 3.10 through 3.14.

## Known gap

Sphinx 5.3 normalizes `str | None` back to `Optional[str]` in rendered autodoc
output (`list[int]` renders correctly). The source is right, the display lags —
fixing it needs a Sphinx bump or `autodoc_typehints` config, out of scope here.
