### PR TITLE
chore: migrate type annotations to PEP 585/604

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 import sys
-from typing import List
 
 sys.path.insert(0, "../")
 
@@ -41,7 +40,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: List[str] = []
+exclude_patterns: list[str] = []
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/nornir_utils/plugins/functions/print_result.py
+++ b/nornir_utils/plugins/functions/print_result.py
@@ -1,7 +1,7 @@
 import logging
 import pprint
 import threading
-from typing import List, cast, Optional, Union
+from typing import cast
 from collections import OrderedDict
 import json
 
@@ -20,7 +20,7 @@ def print_title(title: str) -> None:
     """
     Helper function to print a title.
     """
-    msg = "**** {} ".format(title)
+    msg = f"**** {title} "
     print("{}{}{}{}".format(Style.BRIGHT, Fore.GREEN, msg, "*" * (80 - len(msg))))
 
 
@@ -36,7 +36,7 @@ def _get_color(result: Result, failed: bool) -> str:
 
 def _print_individual_result(
     result: Result,
-    attrs: List[str],
+    attrs: list[str],
     failed: bool,
     severity_level: int,
     task_group: bool = False,
@@ -46,12 +46,12 @@ def _print_individual_result(
         return
 
     color = _get_color(result, failed)
-    subtitle = "" if result.changed is None else " ** changed : {} ".format(result.changed)
+    subtitle = "" if result.changed is None else f" ** changed : {result.changed} "
     level_name = logging.getLevelName(result.severity_level)
     symbol = "v" if task_group else "-"
     host = f"{result.host.name}: " if (print_host and result.host and result.host.name) else ""
-    msg = "{} {}{}{}".format(symbol * 4, host, result.name, subtitle)
-    print("{}{}{}{} {}".format(Style.BRIGHT, color, msg, symbol * (80 - len(msg)), level_name))
+    msg = f"{symbol * 4} {host}{result.name}{subtitle}"
+    print(f"{Style.BRIGHT}{color}{msg}{symbol * (80 - len(msg))} {level_name}")
     for attribute in attrs:
         x = getattr(result, attribute, "")
         if isinstance(x, BaseException):
@@ -67,8 +67,8 @@ def _print_individual_result(
 
 
 def _print_result(
-    result: Union[Result, AggregatedResult, MultiResult],
-    attrs: Optional[List[str]] = None,
+    result: Result | AggregatedResult | MultiResult,
+    attrs: list[str] | None = None,
     failed: bool = False,
     severity_level: int = logging.INFO,
     print_host: bool = False,
@@ -81,10 +81,8 @@ def _print_result(
         msg = result.name
         print("{}{}{}{}".format(Style.BRIGHT, Fore.CYAN, msg, "*" * (80 - len(msg))))
         for host, host_data in sorted(result.items()):
-            title = (
-                "" if host_data.changed is None else " ** changed : {} ".format(host_data.changed)
-            )
-            msg = "* {}{}".format(host, title)
+            title = "" if host_data.changed is None else f" ** changed : {host_data.changed} "
+            msg = f"* {host}{title}"
             print("{}{}{}{}".format(Style.BRIGHT, Fore.BLUE, msg, "*" * (80 - len(msg))))
             _print_result(host_data, attrs, failed, severity_level)
     elif isinstance(result, MultiResult):
@@ -99,7 +97,7 @@ def _print_result(
         for r in result[1:]:
             _print_result(r, attrs, failed, severity_level)
         color = _get_color(result[0], failed)
-        msg = "^^^^ END {} ".format(result[0].name)
+        msg = f"^^^^ END {result[0].name} "
         if result[0].severity_level >= severity_level:
             print("{}{}{}{}".format(Style.BRIGHT, color, msg, "^" * (80 - len(msg))))
     elif isinstance(result, Result):
@@ -107,8 +105,8 @@ def _print_result(
 
 
 def print_result(
-    result: Union[Result, AggregatedResult, MultiResult],
-    vars: Optional[List[str]] = None,
+    result: Result | AggregatedResult | MultiResult,
+    vars: list[str] | None = None,
     failed: bool = False,
     severity_level: int = logging.INFO,
 ) -> None:

--- a/nornir_utils/plugins/inventory/transform_functions.py
+++ b/nornir_utils/plugins/inventory/transform_functions.py
@@ -1,11 +1,8 @@
 import os
-from typing import Optional
 from nornir.core.inventory import Host
 
 
-def load_credentials(
-    host: Host, username: Optional[str] = None, password: Optional[str] = None
-) -> None:
+def load_credentials(host: Host, username: str | None = None, password: str | None = None) -> None:
     """
     load_credentials is an transform_functions to add credentials to every host.
     Environment variables `NORNIR_USERNAME` and `NORNIR_PASSWORD` or arguments can be used.

--- a/nornir_utils/plugins/inventory/yaml_inventory.py
+++ b/nornir_utils/plugins/inventory/yaml_inventory.py
@@ -1,6 +1,6 @@
 import logging
 import pathlib
-from typing import Any, Dict, Type
+from typing import Any
 
 from nornir.core.inventory import (
     Inventory,
@@ -19,7 +19,7 @@ import ruamel.yaml
 logger = logging.getLogger(__name__)
 
 
-def _get_connection_options(data: Dict[str, Any]) -> Dict[str, ConnectionOptions]:
+def _get_connection_options(data: dict[str, Any]) -> dict[str, ConnectionOptions]:
     cp = {}
     for cn, c in data.items():
         cp[cn] = ConnectionOptions(
@@ -33,7 +33,7 @@ def _get_connection_options(data: Dict[str, Any]) -> Dict[str, ConnectionOptions
     return cp
 
 
-def _get_defaults(data: Dict[str, Any]) -> Defaults:
+def _get_defaults(data: dict[str, Any]) -> Defaults:
     return Defaults(
         hostname=data.get("hostname"),
         port=data.get("port"),
@@ -46,7 +46,7 @@ def _get_defaults(data: Dict[str, Any]) -> Defaults:
 
 
 def _get_inventory_element(
-    typ: Type[HostOrGroup], data: Dict[str, Any], name: str, defaults: Defaults
+    typ: type[HostOrGroup], data: dict[str, Any], name: str, defaults: Defaults
 ) -> HostOrGroup:
     return typ(
         name=name,
@@ -90,14 +90,14 @@ class YAMLInventory:
         yml = ruamel.yaml.YAML(typ="safe")
 
         if self.defaults_file.exists():
-            with open(self.defaults_file, "r") as f:
+            with open(self.defaults_file) as f:
                 defaults_dict = yml.load(f) or {}
             defaults = _get_defaults(defaults_dict)
         else:
             defaults = Defaults()
 
         hosts = Hosts()
-        with open(self.host_file, "r") as f:
+        with open(self.host_file) as f:
             hosts_dict = yml.load(f)
 
         for n, h in hosts_dict.items():
@@ -105,7 +105,7 @@ class YAMLInventory:
 
         groups = Groups()
         if self.group_file.exists():
-            with open(self.group_file, "r") as f:
+            with open(self.group_file) as f:
                 groups_dict = yml.load(f) or {}
 
             for n, g in groups_dict.items():

--- a/nornir_utils/plugins/processors/print_result.py
+++ b/nornir_utils/plugins/processors/print_result.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from typing import Union, cast
+from typing import cast
 
 from colorama import Fore, Style, init
 
@@ -10,7 +10,7 @@ from nornir.core.task import AggregatedResult, MultiResult, Result, Task
 init(autoreset=True, strip=False)
 
 
-def _get_color(result: Union[MultiResult, Result]) -> str:
+def _get_color(result: MultiResult | Result) -> str:
     if result.failed:
         color = Fore.RED
     elif result.changed:

--- a/nornir_utils/plugins/tasks/data/load_json.py
+++ b/nornir_utils/plugins/tasks/data/load_json.py
@@ -23,7 +23,7 @@ def load_json(task: Task, file: str) -> Result:
         Result object with the following attributes set:
           * result (``dict``): dictionary with the contents of the file
     """
-    with open(file, "r") as f:
+    with open(file) as f:
         data = json.loads(f.read())
 
     return Result(host=task.host, result=data)

--- a/nornir_utils/plugins/tasks/data/load_yaml.py
+++ b/nornir_utils/plugins/tasks/data/load_yaml.py
@@ -21,7 +21,7 @@ def load_yaml(task: Task, file: str) -> Result:
         Result object with the following attributes set:
           * result (``dict``): dictionary with the contents of the file
     """
-    with open(file, "r") as f:
+    with open(file) as f:
         yml = ruamel.yaml.YAML(typ="safe")
         data = yml.load(f)
 

--- a/nornir_utils/plugins/tasks/files/write_file.py
+++ b/nornir_utils/plugins/tasks/files/write_file.py
@@ -1,15 +1,14 @@
 import difflib
 import os
-from typing import List, Optional
 
 from nornir.core.task import Result, Task
 
 
-def _read_file(file: str) -> List[str]:
+def _read_file(file: str) -> list[str]:
     if not os.path.exists(file):
         return []
 
-    with open(file, "r") as f:
+    with open(file) as f:
         return f.read().splitlines()
 
 
@@ -32,7 +31,7 @@ def write_file(
     filename: str,
     content: str,
     append: bool = False,
-    dry_run: Optional[bool] = None,
+    dry_run: bool | None = None,
 ) -> Result:
     """
     Write contents to a file (locally)

--- a/nornir_utils/plugins/tasks/networking/tcp_ping.py
+++ b/nornir_utils/plugins/tasks/networking/tcp_ping.py
@@ -1,10 +1,9 @@
 import socket
-from typing import Optional, List
 
 from nornir.core.task import Result, Task
 
 
-def tcp_ping(task: Task, ports: List[int], timeout: int = 2, host: Optional[str] = None) -> Result:
+def tcp_ping(task: Task, ports: list[int], timeout: int = 2, host: str | None = None) -> Result:
     """
     Tests connection to a tcp port and tries to establish a three way
     handshake. To be used for network discovery or testing.
@@ -42,7 +41,7 @@ def tcp_ping(task: Task, ports: List[int], timeout: int = 2, host: Optional[str]
                 connection = True
             else:
                 connection = False
-        except (socket.gaierror, socket.timeout, socket.error):
+        except (TimeoutError, OSError, socket.gaierror):
             connection = False
         finally:
             s.close()


### PR DESCRIPTION
Fixes #70

Refactored type hints across the codebase to use modern PEP 585 and PEP 604 syntax (e.g., `list` instead of `List`, `dict` instead of `Dict`, `X | None` instead of `Optional[X]`). This is supported since Python 3.10 is the minimum required version.